### PR TITLE
[Yume Nikki - All translations] Fixed the Menu Theme change text

### DIFF
--- a/yume/fr/Map0078.po
+++ b/yume/fr/Map0078.po
@@ -19,4 +19,4 @@ msgstr "             Changer le thème du menu"
 
 #. ID 2, Page 3, Line 20, Pos (14,8)
 msgid "@@@@@@šƒƒjƒ…[ƒ^ƒCƒvƒ`ƒFƒ“ƒWš"
-msgstr ""
+msgstr "             Changer le thème du menu"

--- a/yume/ja/Map0078.po
+++ b/yume/ja/Map0078.po
@@ -3,13 +3,14 @@ msgstr ""
 "Project-Id-Version: GAME_NAME 1.0\n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: \n"
-"Last-Translator: \n"
+"Last-Translator: Carbonara-Mimigris\n"
 "Language-Team: YOUR NAME <mail@your.address>\n"
+"Language: ja\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-CreatedBy: LcfTrans\n"
-"X-Generator: Poedit 3.0.1\n"
+"X-Generator: Poedit 3.1.1\n"
 
 #. ID 2, Page 1, Line 20, Pos (14,8)
 msgid "                Change Menu Type"
@@ -17,4 +18,4 @@ msgstr "　　　　　　★メニュータイプチェンジ★"
 
 #. ID 2, Page 3, Line 20, Pos (14,8)
 msgid "@@@@@@šƒƒjƒ…[ƒ^ƒCƒvƒ`ƒFƒ“ƒWš"
-msgstr ""
+msgstr "　　　　　　★メニュータイプチェンジ★"

--- a/yume/ko/Map0078.po
+++ b/yume/ko/Map0078.po
@@ -1,14 +1,22 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: GAME_NAME 1.0\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: Carbonara-Mimigris\n"
 "Language-Team: YOUR NAME <mail@your.address>\n"
-"Language: \n"
+"Language: ko\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-CreatedBy: LcfTrans"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-CreatedBy: LcfTrans\n"
+"X-Generator: Poedit 3.1.1\n"
 
 #. ID 2, Page 1, Line 20, Pos (14,8)
 msgid "                Change Menu Type"
 msgstr "                 ★메뉴 타입 변경★"
 
+#. ID 2, Page 3, Line 20, Pos (14,8)
+msgid "@@@@@@šƒƒjƒ…[ƒ^ƒCƒvƒ`ƒFƒ“ƒWš"
+msgstr "                 ★메뉴 타입 변경★"

--- a/yume/ru/Map0078.po
+++ b/yume/ru/Map0078.po
@@ -1,12 +1,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: GAME_NAME 1.0\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: Carbonara-Mimigris\n"
 "Language-Team: YOUR NAME <mail@your.address>\n"
-"Language: \n"
+"Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-CreatedBy: LcfTrans"
+"X-CreatedBy: LcfTrans\n"
+"X-Generator: Poedit 3.1.1\n"
 
 #. ID 2, Page 1, Line 20, Pos (14,8)
 msgid "                Change Menu Type"
@@ -14,5 +18,4 @@ msgstr "                Поменять тип меню"
 
 #. ID 2, Page 3, Line 20, Pos (14,8)
 msgid "@@@@@@šƒƒjƒ…[ƒ^ƒCƒvƒ`ƒFƒ“ƒWš"
-msgstr "Ѓ@Ѓ@Ѓ@Ѓ@Ѓ@Ѓ@ЃљѓЃѓjѓ…Ѓ[ѓ^ѓCѓvѓ`ѓFѓ“ѓWЃљ"
-
+msgstr "                Поменять тип меню"

--- a/yume/zh/Map0078.po
+++ b/yume/zh/Map0078.po
@@ -3,14 +3,14 @@ msgstr ""
 "Project-Id-Version: GAME_NAME 1.0\n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: \n"
-"Last-Translator: \n"
+"Last-Translator: Carbonara-Mimigris\n"
 "Language-Team: YOUR NAME <mail@your.address>\n"
 "Language: ch\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-CreatedBy: LcfTrans\n"
-"X-Generator: Poedit 3.0.1\n"
+"X-Generator: Poedit 3.1.1\n"
 
 #. ID 2, Page 1, Line 20, Pos (14,8)
 msgid "                Change Menu Type"
@@ -18,4 +18,4 @@ msgstr "　　　　　　　　 ★菜单类型转换★"
 
 #. ID 2, Page 3, Line 20, Pos (14,8)
 msgid "@@@@@@šƒƒjƒ…[ƒ^ƒCƒvƒ`ƒFƒ“ƒWš"
-msgstr ""
+msgstr "　　　　　　　　 ★菜单类型转换★"

--- a/yume/zh_tr/Map0078.po
+++ b/yume/zh_tr/Map0078.po
@@ -3,14 +3,14 @@ msgstr ""
 "Project-Id-Version: GAME_NAME 1.0\n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: \n"
-"Last-Translator: \n"
+"Last-Translator: Carbonara-Mimigris\n"
 "Language-Team: YOUR NAME <mail@your.address>\n"
 "Language: ch\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-CreatedBy: LcfTrans\n"
-"X-Generator: Poedit 3.0.1\n"
+"X-Generator: Poedit 3.1.1\n"
 
 #. ID 2, Page 1, Line 20, Pos (14,8)
 msgid "                Change Menu Type"
@@ -18,4 +18,4 @@ msgstr "　　　　　　　　 ★選單類型轉換★"
 
 #. ID 2, Page 3, Line 20, Pos (14,8)
 msgid "@@@@@@šƒƒjƒ…[ƒ^ƒCƒvƒ`ƒFƒ“ƒWš"
-msgstr ""
+msgstr "　　　　　　　　 ★選單類型轉換★"


### PR DESCRIPTION
When using the Traffic Light Effect and interacting with the Toriningen in The Mall to change the Menu, text was completely garbage due to being left untranslated from the Japanese version (again an error of the English version).
Currently on YNO:
![screenshot_7](https://user-images.githubusercontent.com/108797333/185989981-023fcd6d-b30a-49bd-9da4-182fdb271ae8.png)

Normal display and what is on the Japanese Steam Version:
![screenshot_5](https://user-images.githubusercontent.com/108797333/185989759-7c88621d-6dcc-4240-98e8-2535045ca565.png)


