### PR TITLE
Add a readme to the ynotranslations repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,72 @@
+# ynotranslations
+Repository to host translations for the games present on [YNOproject](https://ynoproject.net).
+
+## Installation Instructions
+These instructions will allow you to use these translations offline.
+
+### Requirements
+* Install the [EasyRPG Player](https://easyrpg.org/player/downloads/) (make sure to use the version 0.8.0 or more, this info should be displayed on startup)
+* Download the content of the repository (on the main page of the repository, `Code` -> `Download ZIP`)
+* Download one of the games compatible with the translations available (Yume Nikki requires the [English Steam version](https://store.steampowered.com/app/650700/Yume_Nikki/) and Dream Genie requires the [latest English version](https://ynfg.yume.wiki/Dream_Genie_(梦鬼)#Original), all the other games require to use the latest version released by their author(s) in their original language)
+
+### Process
+1. Unzip the content of the ynotranslations zip
+2. Put the folder containing the translations of the game (named after the name of the game) in the folder of said game (the folder with the MapXXX.lmu files - make sure to put the folder in it, not just its content)
+3. Rename said folder to `Language`
+4. Put the executable of the EasyRPG Player in the folder of the game or one of its root directories and start it (in the latter case, after launching the Player, select the folders leading to the game to start it)
+5. Once on the title screen, you should have an option to change the language of the game
+
+If you want to use a translation for the game Braingirl, you will need to pass the argument `--language {LANGUAGE}` to the executable (where `{LANGUAGE}` is the name of the folder of the translation wanted), which will launch the game directly in the selected language without having to use the language menu. Note that using this argument to start a game without a `Language` folder will force the Player to close, so make sure to not use it in said case.
+
+## Credits
+* aku - Library's books for the English translation of Yume 2kki
+* Aya - Initial French translation of Yume 2kki
+* Carbonara - French translations of Yume Nikki, .flow, Deep Dreams, Someday, Uneven Dream, Braingirl, Muma|Rope, Dream Genie, Mikan Muzou, Ultra Violet, She Awaits, Oversomnia; Misc edits and fixes on the Chinese translation of Yume Nikki, English translation of Yume 2kki, Mikan Muzou, French translation of Answered Prayers; Jigsaw Puzzle World, Plated Snow Country menu, Quick effect menu, Database for the English translation of Yume 2kki; Picture editing help on the Spanish translation of Yume 2kki, Romanian translations of Yume Nikki, Yume 2kki, Uneven Dream, Brazilian Portuguese translation of Yume 2kki; Update of Someday's translations; Testing and maintenance
+* Catmat (貓毯) - Porting and maintenance of the Simplified Chinese and Traditional Chinese translations of Yume Nikki
+* CDMilky - Romanian translation of Yume 2kki
+* CloudyThoughts - Esperanto translation of Yume Nikki
+* Cool Person#8939 (369071 2458) - Finnish translation of Yume Nikki
+* Cottage776 - Misc fixes for the Korean translation of Answered Prayers
+* Eel - English translation of .flow
+* ElTipejoLoco - Spanish translations of Deep Dreams, Mikan Muzou
+* fcoldstar (飛揚寒星) - Simplified Chinese and Traditional Chinese translations of Yume Nikki
+* FlashfyreDev (Sam) - English translation of Yume 2kki; Misc edits on the English translation of Mikan Muzou
+* .flow Chinese Group (.flow汉化组) - Chinese translation of .flow
+* Fonvight - Russian translations of Yume Nikki, Yume 2kki, .flow, Answered Prayers, Deep Dreams, Someday, Uneven Dream, Braingirl, Muma|Rope, Dream Genie, Ultra Violet; English translation of the wallpaper gallery in Yume 2kki
+* FukoSan - Spanish translation of Yume 2kki
+* Gugu (菇菇) - Chinese translation of .flow
+* handsomedove - Korean translation of Yume 2kki
+* Harti - German translation of Yume Nikki
+* Haruku - Korean translation of .flow
+* Kong - Brazilian Portuguese translation of Yume 2kki
+* Jojogape - Spanish translation of Someday
+* KRBlacky - Korean translations of Yume 2kki, Answered Prayers, Deep Dreams
+* Leo9 - Esperanto translation of Yume Nikki
+* lich65 - Korean translation of Yume Nikki
+* Lovena - Initial French translation of Yume 2kki; French translation of Oversomnia
+* maple - Polish translation of Uneven Dream
+* Mhhh (Sundance) - Initial French translation of Yume 2kki; French translation of Answered Prayers
+* Midomido - Japanese translation of Answered Prayers, Deep Dreams, Braingirl, Muma|Rope; English translation of the Debug Room in Yume 2kki
+* miikka847 - Finnish translation of Yume Nikki
+* Moucky233 - Chinese translation of Uneven Dream; Porting of the Chinese translation of Dream Genie; Testing of the Chinese translation of Someday
+* Moustluigi - Initial French translation of Yume 2kki
+* nask - Initial French translation of Yume 2kki
+* nekhnona - Romanian translations of Yume Nikki, Yume 2kki, Uneven Dream
+* Nex0.10 - Porting of the Chinese translation of Dream Genie
+* Niko (Нико) - Spanish translations of Answered Prayers, Muma|Rope, .flow; Spanish translation of Yume 2kki
+* nimiala - Toki Pona translations of Yume Nikki, Yume 2kki
+* Nulsdodage (Wavyup) - Korean translation of Yume 2kki, Someday, English translation of Mikan Muzou
+* portal - Initial French translation of Yume 2kki
+* Sainibi - Japanese translation of Someday
+* Sakura - Japanese translation of Someday
+* Sarah - Simplified Chinese and Traditional Chinese translations of Yume Nikki
+* Shirleycrow - Chinese translation of Someday
+* sniperbob - Hebrew translation of Yume Nikki
+* takne77 - Estonian translation of Yume Nikki
+* TanDen___ ☄ - Chinese translation of Dream Genie
+* Team Compote - French, Japanese translations of Amillusion
+* VioletNeiv - Vietnamese translations of Yume Nikki, Yume 2kki, .flow, Answered Prayers, Deep Dreams
+* Xiaodao (小岛) - Porting of the Simplified Chinese and Traditional Chinese translations of Yume Nikki
+* YNOproject Chinese Team (YNOproject汉化组) - Chinese translation of Deep Dreams, Uneven Dream
+* YouArentDistorted (yugamineena) - English translation of Ultra Violet; Wavy Up, Gimmick Runner, Plated Snow Country & Library's books for the English translation of Yume 2kki
+* Yume 2kki Chinese Translation Group (梦二记汉化组) - Chinese translation of Yume 2kki


### PR DESCRIPTION
Contains installation instructions and credits.
I've tried my best to list everything for the credits but I'm probably missing things since it can be hard to take a look at a lot of commits in a lot of languages, feel free to point anything wrong in need of a fix.
There was a request in the Discord server for specifying a license for the repositories when possible, but I don't think that it will be possible for this one, since the assets are derived work from a game where the license is unclear. Thus, outside of personal use/use for YNOproject, if someone wants to use assets from this repository for another project, you would probably need the authorization from the author of the selected translation.