### PR TITLE
Add game titles to translations

### DIFF
--- a/2kki/en/meta.ini
+++ b/2kki/en/meta.ini
@@ -1,5 +1,6 @@
 [Language]
 Name=English
+GameTitle=Yume 2kki
 Description=Localization by FlashfyreDev
 Code=en_US
 Term=Language

--- a/2kki/fr/meta.ini
+++ b/2kki/fr/meta.ini
@@ -1,5 +1,6 @@
 [Language]
 Name=Français
+GameTitle=Yume 2kki
 Description=Traduction par les membres français du serveur discord
 Code=fr_FR
 Term=　Langue

--- a/2kki/ko/meta.ini
+++ b/2kki/ko/meta.ini
@@ -1,5 +1,6 @@
 [Language]
 Name=한국어
+GameTitle=유메2키
 Description=번역자 KRBlacky
 Code=ko_KR
 Term=　언어

--- a/2kki/pl/meta.ini
+++ b/2kki/pl/meta.ini
@@ -1,5 +1,6 @@
 [Language]
 Name=Polski
+GameTitle=Yume 2kki
 Description=Tłumaczenie wykonane przez krossower1
 Code=pl_PL
 Term=Język

--- a/2kki/pt_br/meta.ini
+++ b/2kki/pt_br/meta.ini
@@ -1,5 +1,6 @@
 [Language]
 Name=Português (Brasileiro)
+GameTitle=Yume 2kki
 Description=Traduzido por ★ Kong ★
 Code=pt_BR
 Term=　Idioma

--- a/2kki/ro/meta.ini
+++ b/2kki/ro/meta.ini
@@ -1,5 +1,6 @@
 [Language]
 Name=Română
+GameTitle=Yume 2kki
 Description=Localizare creată de nekhnona şi CDMilky
 Code=ro_RO
 Term=　 Limbă　

--- a/2kki/vi/meta.ini
+++ b/2kki/vi/meta.ini
@@ -1,5 +1,6 @@
 ﻿[Language]
 Name=Tieng Viet
+GameTitle=Yume 2kki
 Description=Ban dich boi VioletNeiv
 Code=vi_VN
 Term=　Ngôn ngữ　

--- a/2kki/zh/meta.ini
+++ b/2kki/zh/meta.ini
@@ -1,5 +1,6 @@
 [Language]
 Name=简体中文
+GameTitle=梦２记
 Description=汉化 by 梦二记汉化组
 Code=zh_CN
 Term=　  语言

--- a/braingirl/ja/meta.ini
+++ b/braingirl/ja/meta.ini
@@ -1,5 +1,6 @@
 [Language]
 Name=日本語
+GameTitle=ブレインガール
 Description=翻訳 Midomido
 Code=ja_JP
 Term=言語

--- a/deepdreams/ko/meta.ini
+++ b/deepdreams/ko/meta.ini
@@ -1,4 +1,5 @@
 [Language]
 Name=한국어
+GameTitle=딥 드림즈 0.05
 Description=번역자 KRBlacky
 Term=언어

--- a/mikan/en/meta.ini
+++ b/mikan/en/meta.ini
@@ -1,3 +1,4 @@
 [Language]
 Name=English
+GameTitle=Mikan Muzou
 Description=Localized by Nulsdodage.

--- a/mikan/es/meta.ini
+++ b/mikan/es/meta.ini
@@ -1,5 +1,6 @@
 [Language]
 Name=Español
+GameTitle=Mikan Muzou
 Description=Traducción por ElTipejoLoco
 Code=es
 Term=Lenguaje

--- a/mikan/fr/meta.ini
+++ b/mikan/fr/meta.ini
@@ -1,5 +1,6 @@
 [Language]
 Name=Français
+GameTitle=Mikan Muzou
 Description=Traduit par Carbonara.
 Code=fr_FR
 Term=Langue

--- a/prayers/ko/meta.ini
+++ b/prayers/ko/meta.ini
@@ -1,4 +1,5 @@
 [Language]
 Name=한국어
+GameTitle=이루어진 기도들
 Description=번역자 KRBlacky
 Term=언어

--- a/unevendream/zh/meta.ini
+++ b/unevendream/zh/meta.ini
@@ -1,5 +1,6 @@
 [Language]
 Name=简体中文
+GameTitle=凹凸梦 Ver0.08
 Description=汉化 by Moucky233 & YNOprojectCN翻译组(暂定)
 Code=zh_CN
 Term=语言

--- a/yume/ar/Meta.ini
+++ b/yume/ar/Meta.ini
@@ -1,5 +1,6 @@
 [Language]
 Name=Arabic
+GameTitle=حلم من أحلام
 Description=　                                          . المتجدد الحلم / MAZ : العربية النسخة
 Code=ar
 Term=اللغة             　

--- a/yume/ja/meta.ini
+++ b/yume/ja/meta.ini
@@ -1,5 +1,6 @@
 [Language]
 Name=日本語
+GameTitle=ゆめにっき
 Description=日本語
 Code=ja_JP
 Term=言語


### PR DESCRIPTION
For use with the new EasyRPG feature changing the game title when playing on the regular EasyRPG Title only changed if the title in question was used in the translation and is the one used by the community