### PR TITLE
Yume Nikki – Localize yen symbol in Danish translation

### DIFF
--- a/yume/da/RPG_RT.ldb.po
+++ b/yume/da/RPG_RT.ldb.po
@@ -638,7 +638,7 @@ msgstr "装備数"
 
 msgctxt "terms.gold"
 msgid "\\"
-msgstr "円"
+msgstr " yen"
 
 msgctxt "terms.command_attack"
 msgid "UŒ‚"


### PR DESCRIPTION
Change '円' to 'yen' (with one space prepended) in the pause menu.