### PR TITLE
Add a gitignore file to the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# ignore .mo files submitted to the repo
+*.mo


### PR DESCRIPTION
Exclude all mo files from the repository.
When using some tools like Poedit to edit po files, mo files (compiled translation files) are created, which the Player does not use and have no purpose of being here.